### PR TITLE
[iOS] 커스텀 `CalendarPicker`를 사용해 현재 월부터의 캘린더를 띄울 수 있음

### DIFF
--- a/iOS/Targets/Cherrybnb/Sources/Common/Calendar+Extension.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Common/Calendar+Extension.swift
@@ -9,21 +9,24 @@
 import Foundation
 
 extension Calendar {
-    func getNumberOfDaysInMonth(for basedate: Date) -> Int? {
-        return range(of: .day, in: .month, for: basedate)?.count
+    func getNumberOfDaysInMonth(for baseDate: Date) -> Int {
+        // month가 day보다 더 큰 component이므로 range()에서 nil이 return 되지 않음을 확신할 수 있음.
+        return range(of: .day, in: .month, for: baseDate)?.count ?? 0
     }
 
-    func getFirstDayOfMonth(for basedate: Date) -> Date? {
-        return date(from: dateComponents([.year, .month], from: basedate))
+    func getFirstDayOfMonth(for baseDate: Date) -> Date {
+        // baseDateComponents는 반드시 존재하는 일자의 구성 요소이므로 nil이 return 되지 않음을 확신할 수 있음.
+        let baseDateComponents = dateComponents([.year, .month], from: baseDate)
+        return date(from: baseDateComponents) ?? baseDate
     }
 
-    func getNextMonth(for basedate: Date, offset: Int) -> Date? {
-        
-        return date(byAdding: .month, value: offset, to: basedate)
+    func getFirstDayOfMonthAfter(for baseDate: Date, offsetBy: Int) -> Date {
+        // 첫번째 날짜의 다음 달은 반드시 존재하므로 nil이 return 되지 않음을 확신할 수 있음.
+        return date(byAdding: .month, value: offsetBy, to: getFirstDayOfMonth(for: baseDate)) ?? baseDate
     }
 
-    func getNextDay(for basedate: Date, offset: Int) -> Date? {
-        return date(byAdding: .day, value: offset, to: basedate)
+    func getNextDay(for baseDate: Date, offset: Int) -> Date? {
+        return date(byAdding: .day, value: offset, to: baseDate)
     }
 
     func getWeekDay(of date: Date) -> Int {

--- a/iOS/Targets/Cherrybnb/Sources/Common/Calendar+Extension.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Common/Calendar+Extension.swift
@@ -18,6 +18,7 @@ extension Calendar {
     }
 
     func getNextMonth(for basedate: Date, offset: Int) -> Date? {
+        
         return date(byAdding: .month, value: offset, to: basedate)
     }
 

--- a/iOS/Targets/Cherrybnb/Sources/Common/Calendar+Extension.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Common/Calendar+Extension.swift
@@ -25,8 +25,8 @@ extension Calendar {
         return date(byAdding: .month, value: offsetBy, to: getFirstDayOfMonth(for: baseDate)) ?? baseDate
     }
 
-    func getNextDay(for baseDate: Date, offset: Int) -> Date? {
-        return date(byAdding: .day, value: offset, to: baseDate)
+    func getNextDay(for baseDate: Date, offsetBy: Int) -> Date? {
+        return date(byAdding: .day, value: offsetBy, to: baseDate)
     }
 
     func getWeekDay(of date: Date) -> Int {

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
@@ -25,7 +25,7 @@ class CalendarPickerViewController: UIViewController {
 
         collectionView.delegate = self
         collectionView.dataSource = self
-        
+
         collectionView.isScrollEnabled = true
         return collectionView
     }()
@@ -35,10 +35,10 @@ class CalendarPickerViewController: UIViewController {
     var didSelectDate: ((Date) -> Void)?
     var didSelectDataRange: ((Range<Date>) -> Void)?
 
-    init(basedate: Date, numOfMonths: Int,
+    init(baseDate: Date, numOfMonths: Int,
          didDateSelect: ((Date) -> Void)? = nil,
          didDataRangeSelect: ((Range<Date>) -> Void)? = nil) throws {
-        self.calendarPicker = try CalendarPicker(basedate: basedate, numOfMonths: numOfMonths)
+        self.calendarPicker = try CalendarPicker(baseDate: baseDate, numOfMonths: numOfMonths)
 
         self.didSelectDate = didDateSelect
         self.didSelectDataRange = didDataRangeSelect
@@ -54,7 +54,7 @@ class CalendarPickerViewController: UIViewController {
         setSubviews()
         setLayout()
     }
-    
+
     private func setSubviews() {
         view.addSubview(collectionView)
     }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
@@ -43,6 +43,7 @@ class CalendarPickerViewController: UIViewController {
         self.didSelectDate = didDateSelect
         self.didSelectDataRange = didDataRangeSelect
         super.init(nibName: nil, bundle: nil)
+        
     }
 
     required init?(coder: NSCoder) {

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
@@ -35,7 +35,9 @@ class CalendarPickerViewController: UIViewController {
     var didSelectDate: ((Date) -> Void)?
     var didSelectDataRange: ((Range<Date>) -> Void)?
 
-    init(basedate: Date, numOfMonths: Int, didDateSelect: ((Date) -> Void)?, didDataRangeSelect: ((Range<Date>) -> Void)?) throws {
+    init(basedate: Date, numOfMonths: Int,
+         didDateSelect: ((Date) -> Void)? = nil,
+         didDataRangeSelect: ((Range<Date>) -> Void)? = nil) throws {
         self.calendarPicker = try CalendarPicker(basedate: basedate, numOfMonths: numOfMonths)
 
         self.didSelectDate = didDateSelect

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
@@ -37,8 +37,8 @@ class CalendarPickerViewController: UIViewController {
 
     init(baseDate: Date, numOfMonths: Int,
          didDateSelect: ((Date) -> Void)? = nil,
-         didDataRangeSelect: ((Range<Date>) -> Void)? = nil) throws {
-        self.calendarPicker = try CalendarPicker(baseDate: baseDate, numOfMonths: numOfMonths)
+         didDataRangeSelect: ((Range<Date>) -> Void)? = nil) {
+        self.calendarPicker = CalendarPicker(baseDate: baseDate, numOfMonths: numOfMonths)
 
         self.didSelectDate = didDateSelect
         self.didSelectDataRange = didDataRangeSelect

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/CalendarPicker.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/CalendarPicker.swift
@@ -16,7 +16,7 @@ struct CalendarPicker {
         let firstMonth = Month(baseDate: baseDate)
 
         let afterMonths: [Month] = (1..<numOfMonths).map { offset in
-            let firstDayOfMonthAfter = CalendarPicker.KRCalendar.getFirstDayOfMonthAfter(for: baseDate, offsetBy: offset)
+            let firstDayOfMonthAfter = Calendar.current.getFirstDayOfMonthAfter(for: baseDate, offsetBy: offset)
             return Month(baseDate: firstDayOfMonthAfter)
         }
 

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/CalendarPicker.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/CalendarPicker.swift
@@ -13,8 +13,6 @@ struct CalendarPicker {
     private var months: [Month]
 
     init(baseDate: Date, numOfMonths: Int) {
-        // BaseDate를 기준으로 Month 모델을 생성해서 저장.
-
         let firstMonth = Month(baseDate: baseDate)
 
         let afterMonths: [Month] = (1..<numOfMonths).map { offset in
@@ -25,22 +23,18 @@ struct CalendarPicker {
         self.months = [firstMonth] + afterMonths
     }
 
-    // 전체 Month 섹션의 갯수를 리턴함.
     var monthCount: Int {
         return months.count
     }
 
-    // 특정 Month 섹션을 모두 리턴함.
     func getMonth(monthSection: Int) -> Month {
         return months[monthSection]
     }
 
-    // 특정 먼스 섹션의 전체 Day 갯수를 return함.
     func dayCount(monthSection: Int) -> Int {
         return months[monthSection].days.count
     }
 
-    // 특정 먼스 섹션의 특정 Day를 리턴함.
     func getDay(monthSection: Int, dayItem: Int) -> Day {
         return months[monthSection].days[dayItem]
     }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/CalendarPicker.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/CalendarPicker.swift
@@ -9,51 +9,42 @@
 import Foundation
 
 struct CalendarPicker {
-    
+
     private var months: [Month]
-    
-    init(basedate: Date, numOfMonths: Int) throws {
+
+    init(baseDate: Date, numOfMonths: Int) {
         // BaseDate를 기준으로 Month 모델을 생성해서 저장.
-        
-        let firstMonth = try Month(basedate: basedate)
-        
-        guard let firstDayOfMonth = CalendarPicker.KRCalendar.getFirstDayOfMonth(for: basedate) else {
-            throw CalendarPickerError.metadataGeneration
+
+        let firstMonth = Month(baseDate: baseDate)
+
+        let afterMonths: [Month] = (1..<numOfMonths).map { offset in
+            let firstDayOfMonthAfter = CalendarPicker.KRCalendar.getFirstDayOfMonthAfter(for: baseDate, offsetBy: offset)
+            return Month(baseDate: firstDayOfMonthAfter)
         }
-        
-        let afterMonths: [Month] = try (1..<numOfMonths).map { offset in
-            
-            
-            guard let firstDayOfMonthAfter = CalendarPicker.KRCalendar.getNextMonth(for: firstDayOfMonth, offset: offset) else {
-                throw CalendarPickerError.offsetMonthGeneration
-            }
-            
-            return try Month(basedate: firstDayOfMonthAfter)
-        }
-        
+
         self.months = [firstMonth] + afterMonths
     }
-    
+
     // 전체 Month 섹션의 갯수를 리턴함.
     var monthCount: Int {
         return months.count
     }
-    
+
     // 특정 Month 섹션을 모두 리턴함.
     func getMonth(monthSection: Int) -> Month {
         return months[monthSection]
     }
-    
+
     // 특정 먼스 섹션의 전체 Day 갯수를 return함.
     func dayCount(monthSection: Int) -> Int {
         return months[monthSection].days.count
     }
-    
+
     // 특정 먼스 섹션의 특정 Day를 리턴함.
     func getDay(monthSection: Int, dayItem: Int) -> Day {
         return months[monthSection].days[dayItem]
     }
-    
+
     func select(monthSection: Int, dayItem: Int) {
         // 특정 데이트를 select함.
         // 그러면 해당 특정 데이트에 해당하는 Day 모델을 업데이트함.
@@ -69,7 +60,6 @@ extension CalendarPicker {
         return calendar
     }()
 }
-
 
 enum CalendarPickerError: Error {
     case metadataGeneration

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/Month.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/Month.swift
@@ -16,22 +16,22 @@ extension CalendarPicker {
         let days: [Day]
 
         init(baseDate: Date) {
-            let numberOfDaysInMonth = CalendarPicker.KRCalendar.getNumberOfDaysInMonth(for: baseDate)
-            let firstDayOfMonth = CalendarPicker.KRCalendar.getFirstDayOfMonth(for: baseDate)
-            let firstDayWeekday = CalendarPicker.KRCalendar.getWeekDay(of: firstDayOfMonth)
+            let numberOfDaysInMonth = Calendar.current.getNumberOfDaysInMonth(for: baseDate)
+            let firstDayOfMonth = Calendar.current.getFirstDayOfMonth(for: baseDate)
+            let firstDayWeekday = Calendar.current.getWeekDay(of: firstDayOfMonth)
 
             self.numberOfDays = numberOfDaysInMonth
             self.firstDay = firstDayOfMonth
             self.firstDayWeekday = firstDayWeekday
 
             let daysOfLastMonth: [Day] = (1..<firstDayWeekday).reversed().map { offset in
-                let date = CalendarPicker.KRCalendar.getNextDay(for: firstDayOfMonth, offsetBy: -offset) ?? firstDayOfMonth
+                let date = Calendar.current.getNextDay(for: firstDayOfMonth, offsetBy: -offset) ?? firstDayOfMonth
                 return Day(date: date, isSelected: false, isPast: true, isHidden: true)
             }
 
             let days: [Day] = (0..<numberOfDays).map { offset in
-                let date = CalendarPicker.KRCalendar.getNextDay(for: firstDayOfMonth, offsetBy: offset) ?? firstDayOfMonth
-                let isPast = date < baseDate
+                let date = Calendar.current.getNextDay(for: firstDayOfMonth, offsetBy: offset) ?? firstDayOfMonth
+                let isPast = date <  Calendar.current.startOfDay(for: baseDate)
                 return Day(date: date, isSelected: false, isPast: isPast, isHidden: false)
             }
 

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/Month.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/Month.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension CalendarPicker {
     struct Month {
-        var numberOfNonEmptyDays: Int
+        var numberOfDays: Int
         let firstDay: Date
         let firstDayWeekday: Int
         let days: [Day]
@@ -20,32 +20,29 @@ extension CalendarPicker {
             let firstDayOfMonth = CalendarPicker.KRCalendar.getFirstDayOfMonth(for: baseDate)
             let firstDayWeekday = CalendarPicker.KRCalendar.getWeekDay(of: firstDayOfMonth)
 
-            self.numberOfNonEmptyDays = numberOfDaysInMonth
+            self.numberOfDays = numberOfDaysInMonth
             self.firstDay = firstDayOfMonth
             self.firstDayWeekday = firstDayWeekday
 
-            let emptyDays = (1..<firstDayWeekday).map { _ in
-                return Day(date: nil, isSelected: false, isPast: nil)
+            let daysOfLastMonth: [Day] = (1..<firstDayWeekday).reversed().map { offset in
+                let date = CalendarPicker.KRCalendar.getNextDay(for: firstDayOfMonth, offsetBy: -offset) ?? firstDayOfMonth
+                return Day(date: date, isSelected: false, isPast: true, isHidden: true)
             }
 
-            let days: [Day] = (0..<numberOfNonEmptyDays).map { offset in
-                let date = CalendarPicker.KRCalendar.getNextDay(for: firstDayOfMonth, offset: offset) ?? firstDayOfMonth
+            let days: [Day] = (0..<numberOfDays).map { offset in
+                let date = CalendarPicker.KRCalendar.getNextDay(for: firstDayOfMonth, offsetBy: offset) ?? firstDayOfMonth
                 let isPast = date < baseDate
-                return Day(date: date, isSelected: false, isPast: isPast)
+                return Day(date: date, isSelected: false, isPast: isPast, isHidden: false)
             }
 
-            self.days = emptyDays + days
+            self.days = daysOfLastMonth + days
         }
     }
 
     struct Day {
-        // Day가 나타내는 시점(일)
-        let date: Date?
-
-        // Calendar에서 선택되었는지 여부
-        let isSelected: Bool?
-
-        // 현재 이전 날짜인지 여부
-        let isPast: Bool?
+        let date: Date
+        let isSelected: Bool
+        let isPast: Bool
+        let isHidden: Bool
     }
 }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/Month.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/Month.swift
@@ -14,26 +14,23 @@ extension CalendarPicker {
         let firstDay: Date
         let firstDayWeekday: Int
         let days: [Day]
-        
-        init(basedate: Date) throws {
-            guard let numberOfDaysInMonth = CalendarPicker.KRCalendar.getNumberOfDaysInMonth(for: basedate),
-                  let firstDayOfMonth = CalendarPicker.KRCalendar.getFirstDayOfMonth(for: basedate) else {
-                throw CalendarPickerError.metadataGeneration
-            }
 
+        init(baseDate: Date) {
+            let numberOfDaysInMonth = CalendarPicker.KRCalendar.getNumberOfDaysInMonth(for: baseDate)
+            let firstDayOfMonth = CalendarPicker.KRCalendar.getFirstDayOfMonth(for: baseDate)
             let firstDayWeekday = CalendarPicker.KRCalendar.getWeekDay(of: firstDayOfMonth)
 
             self.numberOfNonEmptyDays = numberOfDaysInMonth
             self.firstDay = firstDayOfMonth
             self.firstDayWeekday = firstDayWeekday
-            
+
             let emptyDays = (1..<firstDayWeekday).map { _ in
                 return Day(date: nil, isSelected: false, isPast: nil)
             }
 
             let days: [Day] = (0..<numberOfNonEmptyDays).map { offset in
                 let date = CalendarPicker.KRCalendar.getNextDay(for: firstDayOfMonth, offset: offset) ?? firstDayOfMonth
-                let isPast = date < basedate
+                let isPast = date < baseDate
                 return Day(date: date, isSelected: false, isPast: isPast)
             }
 

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/View/CalendarPickerViewCell.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/View/CalendarPickerViewCell.swift
@@ -10,13 +10,13 @@ import UIKit
 
 class CalendarPickerViewCell: UICollectionViewCell {
     static let reuseIdentifier = String(describing: CalendarPickerViewCell.self)
-
+    
     private let dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "d"
         return dateFormatter
     }()
-
+    
     private lazy var selectionBackgroundView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -24,7 +24,7 @@ class CalendarPickerViewCell: UICollectionViewCell {
         view.backgroundColor = .black
         return view
     }()
-
+    
     private lazy var numberLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -33,51 +33,60 @@ class CalendarPickerViewCell: UICollectionViewCell {
         label.textColor = .label
         return label
     }()
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setSubviews()
         setLayout()
     }
-
+    
     private var day: CalendarPicker.Day?
-
+    
     func setDay(_ day: CalendarPicker.Day) {
         self.day = day
         
         guard !day.isHidden else { return }
-
+        
         let dateString = dateFormatter.string(from: day.date)
-
-        if day.isPast {
-            numberLabel.attributedText = strikethrough(dateString)
-        } else {
-            numberLabel.text = dateString
-        }
+        
+        numberLabel.attributedText = day.isPast ? strikethrough(dateString) : normal(dateString)
     }
-
+    
     private func strikethrough(_ string: String) -> NSAttributedString {
-        let attributes: [NSAttributedString.Key: Any] = [.strikethroughStyle: NSUnderlineStyle.single.rawValue, .strikethroughColor: UIColor.systemGray, .foregroundColor: UIColor.systemGray]
-
+        let attributes: [NSAttributedString.Key: Any] = [
+            .strikethroughStyle: NSUnderlineStyle.single.rawValue,
+            .strikethroughColor: UIColor.systemGray,
+            .foregroundColor: UIColor.systemGray]
+        
         return NSAttributedString(string: string, attributes: attributes)
-
+        
     }
-
+    
+    private func normal(_ string: String) -> NSAttributedString {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.systemFont(ofSize: 18, weight: .medium),
+            .strikethroughStyle: "nil",
+            .foregroundColor: UIColor.black]
+        
+        return NSAttributedString(string: string, attributes: attributes)
+        
+    }
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     private func setSubviews() {
         contentView.addSubview(numberLabel)
     }
-
+    
     private func setLayout() {
         NSLayoutConstraint.activate([
             numberLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
             numberLabel.centerXAnchor.constraint(equalTo: centerXAnchor)
         ])
     }
-
+    
     override func prepareForReuse() {
         day = nil
         numberLabel.text = nil

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/View/CalendarPickerViewCell.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/View/CalendarPickerViewCell.swift
@@ -44,11 +44,12 @@ class CalendarPickerViewCell: UICollectionViewCell {
 
     func setDay(_ day: CalendarPicker.Day) {
         self.day = day
-        guard let date = day.date, let isPast = day.isPast else { return }
+        
+        guard !day.isHidden else { return }
 
-        let dateString = dateFormatter.string(from: date)
+        let dateString = dateFormatter.string(from: day.date)
 
-        if isPast {
+        if day.isPast {
             numberLabel.attributedText = strikethrough(dateString)
         } else {
             numberLabel.text = dateString

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/View/LocationCell.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/View/LocationCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class LocationCell: UICollectionViewCell {
     static let reuseIdentifier = String(describing: LocationCell.self)
-    
+
     lazy var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -18,14 +18,14 @@ class LocationCell: UICollectionViewCell {
         imageView.layer.cornerRadius = 10
         return imageView
     }()
-    
+
     lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = .systemFont(ofSize: 17)
         return label
     }()
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         contentView.addSubview(imageView)
@@ -36,8 +36,8 @@ class LocationCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-        
-    private func setLayout(){
+
+    private func setLayout() {
         NSLayoutConstraint.activate([
             imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
@@ -45,7 +45,7 @@ class LocationCell: UICollectionViewCell {
             imageView.heightAnchor.constraint(equalToConstant: 64),
             imageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
-    
+
         NSLayoutConstraint.activate([
             titleLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 16),
             titleLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/View/PlaceCell.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/View/PlaceCell.swift
@@ -9,9 +9,9 @@
 import UIKit
 
 class PlaceCell: UICollectionViewCell {
-    
+
     static let reuseIdentifier = String(describing: PlaceCell.self)
-    
+
     lazy var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -20,7 +20,7 @@ class PlaceCell: UICollectionViewCell {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
     }()
-    
+
     lazy var nameLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -28,7 +28,7 @@ class PlaceCell: UICollectionViewCell {
         label.text = "서울"
         return label
     }()
-    
+
     lazy var distanceLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -58,7 +58,7 @@ class PlaceCell: UICollectionViewCell {
         imageView.heightAnchor.constraint(equalToConstant: 64),
         imageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
-        
+
         NSLayoutConstraint.activate([
         nameLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 16),
         nameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),

--- a/iOS/Targets/Cherrybnb/Sources/Support/AppDelegate.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Support/AppDelegate.swift
@@ -10,9 +10,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
-        let storyboard = UIStoryboard(name: "Main", bundle: .main)
-        let viewController = storyboard.instantiateInitialViewController()
+//        let storyboard = UIStoryboard(name: "Main", bundle: .main)
+//        let viewController = storyboard.instantiateInitialViewController()
 
+        let viewController = CalendarPickerViewController(baseDate: Date(), numOfMonths: 12)
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()
 

--- a/iOS/Targets/Cherrybnb/Tests/CalendarPickerSpec.swift
+++ b/iOS/Targets/Cherrybnb/Tests/CalendarPickerSpec.swift
@@ -17,28 +17,28 @@ class CalendarPickerSpec: QuickSpec {
             var testDate: Date!
             var calendarPicker: CalendarPicker!
             var calendar: Calendar!
-            
+
             beforeEach {
                 calendar = Calendar(identifier: .gregorian)
-                
+
                 let dateFormatter = DateFormatter()
                 dateFormatter.dateFormat = "YY,M,d-HH:mm:ss"
                 testDate = dateFormatter.date(from: "22,05,15-07:00:00")
-                
-                calendarPicker = try? CalendarPicker(basedate: testDate, numOfMonths: 12)
+
+                calendarPicker = CalendarPicker(baseDate: testDate, numOfMonths: 12)
             }
 
             context("아무것도 하지 않으면") {
                 it("기준일이 속한 월과 첫번째 월이 서로 같아야 한다") {
                     let firstMonth = calendarPicker.getMonth(monthSection: 0)
-                    let monthOfTestDate =  calendar.getFirstDayOfMonth(for: testDate)!
-                    
+                    let monthOfTestDate =  calendar.getFirstDayOfMonth(for: testDate)
+
                     expect(firstMonth.firstDay).to(equal(monthOfTestDate))
                 }
 
                 it("첫번째 월에서 기준일 이전의 날짜는 모두 '지난 날짜'로 표시돼야 한다") {
                     let firstMonth = calendarPicker.getMonth(monthSection: 0)
-                    
+
                     let pastDays = firstMonth.days.filter { day in
                         if let day = day.date {
                             return day < testDate
@@ -46,15 +46,15 @@ class CalendarPickerSpec: QuickSpec {
                             return false
                         }
                     }
-                    
+
                     for pastDay in pastDays {
                         expect(pastDay.isPast).to(equal(true))
                     }
                 }
-                
+
                 it("첫번째 월에서 기준일 포함한 이후 날짜는 모두 '지나지 않은 날짜'로 표시돼야 한다") {
                     let firstMonth = calendarPicker.getMonth(monthSection: 0)
-                    
+
                     let futureDays = firstMonth.days.filter { day in
                         if let day = day.date {
                             return day >= testDate
@@ -62,25 +62,25 @@ class CalendarPickerSpec: QuickSpec {
                             return false
                         }
                     }
-                    
+
                     for futureDay in futureDays {
                         expect(futureDay.isPast).to(equal(false))
                     }
                 }
-                
+
                 it("일요일(weekday 1)이 맨 앞 순서(index 0)로 나와야 한다. 즉, (7a + b)번째 순서인 날짜는 b-1요일을 나타내야한다.") {
                     let firstMonth = calendarPicker.getMonth(monthSection: 0)
-                    
+
                     for (i, day) in firstMonth.days.enumerated() {
                         guard let date = day.date else { return }
                         let indexRemainder = i % 7
                         let weekday = calendar.getWeekDay(of: date)
-                        
+
                         expect(indexRemainder).to(equal(weekday-1))
                     }
-                    
+
                 }
-                
+
             }
         }
 

--- a/iOS/Targets/Cherrybnb/Tests/CalendarPickerSpec.swift
+++ b/iOS/Targets/Cherrybnb/Tests/CalendarPickerSpec.swift
@@ -40,11 +40,7 @@ class CalendarPickerSpec: QuickSpec {
                     let firstMonth = calendarPicker.getMonth(monthSection: 0)
 
                     let pastDays = firstMonth.days.filter { day in
-                        if let day = day.date {
-                            return day < testDate
-                        } else {
-                            return false
-                        }
+                        return day.date < testDate
                     }
 
                     for pastDay in pastDays {
@@ -56,11 +52,7 @@ class CalendarPickerSpec: QuickSpec {
                     let firstMonth = calendarPicker.getMonth(monthSection: 0)
 
                     let futureDays = firstMonth.days.filter { day in
-                        if let day = day.date {
-                            return day >= testDate
-                        } else {
-                            return false
-                        }
+                        return day.date >= testDate
                     }
 
                     for futureDay in futureDays {
@@ -72,9 +64,8 @@ class CalendarPickerSpec: QuickSpec {
                     let firstMonth = calendarPicker.getMonth(monthSection: 0)
 
                     for (i, day) in firstMonth.days.enumerated() {
-                        guard let date = day.date else { return }
                         let indexRemainder = i % 7
-                        let weekday = calendar.getWeekDay(of: date)
+                        let weekday = calendar.getWeekDay(of: day.date)
 
                         expect(indexRemainder).to(equal(weekday-1))
                     }

--- a/iOS/Targets/Cherrybnb/Tests/CalendarPickerSpec.swift
+++ b/iOS/Targets/Cherrybnb/Tests/CalendarPickerSpec.swift
@@ -16,11 +16,8 @@ class CalendarPickerSpec: QuickSpec {
         describe("특정 시각을 기준으로 캘린더 피커를 생성한 상태에서") {
             var testDate: Date!
             var calendarPicker: CalendarPicker!
-            var calendar: Calendar!
 
             beforeEach {
-                calendar = Calendar(identifier: .gregorian)
-
                 let dateFormatter = DateFormatter()
                 dateFormatter.dateFormat = "YY,M,d-HH:mm:ss"
                 testDate = dateFormatter.date(from: "22,05,15-07:00:00")
@@ -31,7 +28,7 @@ class CalendarPickerSpec: QuickSpec {
             context("아무것도 하지 않으면") {
                 it("기준일이 속한 월과 첫번째 월이 서로 같아야 한다") {
                     let firstMonth = calendarPicker.getMonth(monthSection: 0)
-                    let monthOfTestDate =  calendar.getFirstDayOfMonth(for: testDate)
+                    let monthOfTestDate = CalendarPicker.KRCalendar.getFirstDayOfMonth(for: testDate)
 
                     expect(firstMonth.firstDay).to(equal(monthOfTestDate))
                 }
@@ -65,7 +62,7 @@ class CalendarPickerSpec: QuickSpec {
 
                     for (i, day) in firstMonth.days.enumerated() {
                         let indexRemainder = i % 7
-                        let weekday = calendar.getWeekDay(of: day.date)
+                        let weekday = CalendarPicker.KRCalendar.getWeekDay(of: day.date)
 
                         expect(indexRemainder).to(equal(weekday-1))
                     }

--- a/iOS/Targets/Cherrybnb/Tests/CalendarPickerSpec.swift
+++ b/iOS/Targets/Cherrybnb/Tests/CalendarPickerSpec.swift
@@ -28,16 +28,16 @@ class CalendarPickerSpec: QuickSpec {
             context("아무것도 하지 않으면") {
                 it("기준일이 속한 월과 첫번째 월이 서로 같아야 한다") {
                     let firstMonth = calendarPicker.getMonth(monthSection: 0)
-                    let monthOfTestDate = CalendarPicker.KRCalendar.getFirstDayOfMonth(for: testDate)
+                    let monthOfTestDate = Calendar.current.getFirstDayOfMonth(for: testDate)
 
                     expect(firstMonth.firstDay).to(equal(monthOfTestDate))
                 }
 
-                it("첫번째 월에서 기준일 이전의 날짜는 모두 '지난 날짜'로 표시돼야 한다") {
+                it("첫번째 월에서 기준일 시작 시각 이전의 날짜는 모두 '지난 날짜'로 표시돼야 한다") {
                     let firstMonth = calendarPicker.getMonth(monthSection: 0)
 
                     let pastDays = firstMonth.days.filter { day in
-                        return day.date < testDate
+                        return day.date < Calendar.current.startOfDay(for: testDate)
                     }
 
                     for pastDay in pastDays {
@@ -45,11 +45,11 @@ class CalendarPickerSpec: QuickSpec {
                     }
                 }
 
-                it("첫번째 월에서 기준일 포함한 이후 날짜는 모두 '지나지 않은 날짜'로 표시돼야 한다") {
+                it("첫번째 월에서 기준일 시작 시각을 포함한 이후 날짜는 모두 '지나지 않은 날짜'로 표시돼야 한다") {
                     let firstMonth = calendarPicker.getMonth(monthSection: 0)
 
                     let futureDays = firstMonth.days.filter { day in
-                        return day.date >= testDate
+                        return day.date >= Calendar.current.startOfDay(for: testDate)
                     }
 
                     for futureDay in futureDays {
@@ -62,7 +62,7 @@ class CalendarPickerSpec: QuickSpec {
 
                     for (i, day) in firstMonth.days.enumerated() {
                         let indexRemainder = i % 7
-                        let weekday = CalendarPicker.KRCalendar.getWeekDay(of: day.date)
+                        let weekday = Calendar.current.getWeekDay(of: day.date)
 
                         expect(indexRemainder).to(equal(weekday-1))
                     }

--- a/iOS/Targets/Cherrybnb/Tests/CalendarPickerSpec.swift
+++ b/iOS/Targets/Cherrybnb/Tests/CalendarPickerSpec.swift
@@ -1,0 +1,88 @@
+//
+//  CalendarSpec.swift
+//  CherrybnbTests
+//
+//  Created by Bumgeun Song on 2022/05/31.
+//  Copyright © 2022 Codesquad. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+
+class CalendarPickerSpec: QuickSpec {
+    override func spec() {
+
+        describe("특정 시각을 기준으로 캘린더 피커를 생성한 상태에서") {
+            var testDate: Date!
+            var calendarPicker: CalendarPicker!
+            var calendar: Calendar!
+            
+            beforeEach {
+                calendar = Calendar(identifier: .gregorian)
+                
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "YY,M,d-HH:mm:ss"
+                testDate = dateFormatter.date(from: "22,05,15-07:00:00")
+                
+                calendarPicker = try? CalendarPicker(basedate: testDate, numOfMonths: 12)
+            }
+
+            context("아무것도 하지 않으면") {
+                it("기준일이 속한 월과 첫번째 월이 서로 같아야 한다") {
+                    let firstMonth = calendarPicker.getMonth(monthSection: 0)
+                    let monthOfTestDate =  calendar.getFirstDayOfMonth(for: testDate)!
+                    
+                    expect(firstMonth.firstDay).to(equal(monthOfTestDate))
+                }
+
+                it("첫번째 월에서 기준일 이전의 날짜는 모두 '지난 날짜'로 표시돼야 한다") {
+                    let firstMonth = calendarPicker.getMonth(monthSection: 0)
+                    
+                    let pastDays = firstMonth.days.filter { day in
+                        if let day = day.date {
+                            return day < testDate
+                        } else {
+                            return false
+                        }
+                    }
+                    
+                    for pastDay in pastDays {
+                        expect(pastDay.isPast).to(equal(true))
+                    }
+                }
+                
+                it("첫번째 월에서 기준일 포함한 이후 날짜는 모두 '지나지 않은 날짜'로 표시돼야 한다") {
+                    let firstMonth = calendarPicker.getMonth(monthSection: 0)
+                    
+                    let futureDays = firstMonth.days.filter { day in
+                        if let day = day.date {
+                            return day >= testDate
+                        } else {
+                            return false
+                        }
+                    }
+                    
+                    for futureDay in futureDays {
+                        expect(futureDay.isPast).to(equal(false))
+                    }
+                }
+                
+                it("일요일(weekday 1)이 맨 앞 순서(index 0)로 나와야 한다. 즉, (7a + b)번째 순서인 날짜는 b-1요일을 나타내야한다.") {
+                    let firstMonth = calendarPicker.getMonth(monthSection: 0)
+                    
+                    for (i, day) in firstMonth.days.enumerated() {
+                        guard let date = day.date else { return }
+                        let indexRemainder = i % 7
+                        let weekday = calendar.getWeekDay(of: date)
+                        
+                        expect(indexRemainder).to(equal(weekday-1))
+                    }
+                    
+                }
+                
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
## 작업 목록
#20 

- [ ] CalendarPicker 모델에 대한 테스트 케이스 추가
- [ ] CalendarPicker의 뷰 관련 에러 수정
- [ ] Day 구조체가 Optional 값을 갖지 않도록 수정

## Screenshot
(현재 RootViewController를 CalendarPicker로 바꿔놓은 상태임)

![Screen Shot 2022-05-31 at 3 59 09 PM](https://user-images.githubusercontent.com/17468015/171111686-95a5309d-0bcb-4069-8c67-390377535579.png)


## 고민과 해결
#25 