### PR TITLE
[iOS] 검색 결과 리스트에서 선택한 지역이 하나가 될 때까지 다시 선택할 수 있음.

### DIFF
--- a/iOS/Targets/Cherrybnb/Sources/Common/PlaceFactory.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Common/PlaceFactory.swift
@@ -1,0 +1,24 @@
+//
+//  PlaceFactory.swift
+//  Cherrybnb
+//
+//  Created by 최예주 on 2022/06/03.
+//  Copyright © 2022 Codesquad. All rights reserved.
+//
+
+import Foundation
+import MapKit
+
+class PlaceFactory{
+    
+    static func makePlace(with mapItem: MKMapItem) -> Place?{
+        guard let placeName = mapItem.name else { return nil }
+        let latitude = mapItem.placemark.coordinate.latitude as Coordinate.Degree
+        let longitude = mapItem.placemark.coordinate.longitude as Coordinate.Degree
+        let coordinate = Coordinate(latitude: latitude, longitude: longitude)
+        let location = Location(coordinate: coordinate)
+        
+        return Place(name: placeName, location: location, estimatedTime: 0)
+    }
+    
+}

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/SearchDateViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/SearchDateViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 struct QueryParameter {
-    var location: Location?
     var dateRange: Range<Date>?
     var place: Place?
 }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/SearchDateViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/SearchDateViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 struct QueryParameter {
     var location: Location?
     var dateRange: Range<Date>?
+    var place: Place?
 }
 
 class SearchDateViewController: UIViewController {

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/DetailSearchDataSource.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/DetailSearchDataSource.swift
@@ -1,0 +1,37 @@
+//
+//  DetailSearchLocationDataSource.swift
+//  Cherrybnb
+//
+//  Created by 최예주 on 2022/06/02.
+//  Copyright © 2022 Codesquad. All rights reserved.
+//
+
+import UIKit
+import MapKit
+
+class DetailSearchLocationDataSource: NSObject, UICollectionViewDataSource {
+    
+    private var searchResultData = [MKMapItem]()
+    
+    func setSearchResultData(_ data: [MKMapItem]) {
+        searchResultData = data
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return searchResultData.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LocationCell.reuseIdentifier, for: indexPath) as? LocationCell else { return UICollectionViewCell() }
+        let data = searchResultData[indexPath.item]
+        if let name = data.name {
+            cell.setLocationData(name)
+        }
+    
+        return cell
+    }
+    
+    
+    
+    
+}

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/DetailSearchDataSource.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/DetailSearchDataSource.swift
@@ -11,7 +11,7 @@ import MapKit
 
 class DetailSearchLocationDataSource: NSObject, UICollectionViewDataSource {
     
-    private var searchResultData = [MKMapItem]()
+    private(set) var searchResultData = [MKMapItem]()
     
     func setSearchResultData(_ data: [MKMapItem]) {
         searchResultData = data

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/DetailSearchDelegate.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/DetailSearchDelegate.swift
@@ -1,0 +1,34 @@
+//
+//  DetailSearchDelegate.swift
+//  Cherrybnb
+//
+//  Created by 최예주 on 2022/06/02.
+//  Copyright © 2022 Codesquad. All rights reserved.
+//
+
+import UIKit
+
+class DetailSearchDelegate: NSObject, UICollectionViewDelegate {
+    
+    let searchDateVC = SearchDateViewController()
+    let navigationController: UINavigationController?
+    let collectionView: UICollectionView?
+    
+    init(navigation: UINavigationController, collectionView: UICollectionView){
+        self.navigationController = navigation
+        self.collectionView = collectionView
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        self.navigationController?.pushViewController(searchDateVC, animated: true)
+    }
+}
+
+
+extension DetailSearchDelegate: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        guard let collectionView = self.collectionView else { return CGSize()}
+        let size = CGSize(width: collectionView.frame.width, height: 64)
+        return size
+    }
+}

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/DetailSearchDelegate.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/DetailSearchDelegate.swift
@@ -20,6 +20,17 @@ class DetailSearchDelegate: NSObject, UICollectionViewDelegate {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        guard let datasource = self.collectionView?.dataSource as? DetailSearchLocationDataSource else { return }
+        let mapItem = datasource.searchResultData[0]
+        guard let placeName = mapItem.name else { return }
+        let latitude = mapItem.placemark.coordinate.latitude as Coordinate.Degree
+        let longitude = mapItem.placemark.coordinate.longitude as Coordinate.Degree
+        let coordinate = Coordinate(latitude: latitude, longitude: longitude)
+        
+        let place = Place(name: placeName, location: Location(coordinate: coordinate), estimatedTime: 0)
+      
+        searchDateVC.queryParameter?.place = place
         self.navigationController?.pushViewController(searchDateVC, animated: true)
     }
 }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/DetailSearchDelegate.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/DetailSearchDelegate.swift
@@ -23,13 +23,7 @@ class DetailSearchDelegate: NSObject, UICollectionViewDelegate {
         
         guard let datasource = self.collectionView?.dataSource as? DetailSearchLocationDataSource else { return }
         let mapItem = datasource.searchResultData[0]
-        guard let placeName = mapItem.name else { return }
-        let latitude = mapItem.placemark.coordinate.latitude as Coordinate.Degree
-        let longitude = mapItem.placemark.coordinate.longitude as Coordinate.Degree
-        let coordinate = Coordinate(latitude: latitude, longitude: longitude)
-        
-        let place = Place(name: placeName, location: Location(coordinate: coordinate), estimatedTime: 0)
-      
+        guard let place = PlaceFactory.makePlace(with: mapItem) else { return }
         searchDateVC.queryParameter?.place = place
         self.navigationController?.pushViewController(searchDateVC, animated: true)
     }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/RecommandDelegate.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/RecommandDelegate.swift
@@ -1,0 +1,40 @@
+//
+//  SearchLocationDelegate.swift
+//  Cherrybnb
+//
+//  Created by 최예주 on 2022/06/03.
+//  Copyright © 2022 Codesquad. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class RecommandationDelegate: NSObject, UICollectionViewDelegate {
+    
+    let navigationController: UINavigationController?
+    let collectionView: UICollectionView?
+    
+    init(navigation: UINavigationController, collectionView: UICollectionView){
+        self.navigationController = navigation
+        self.collectionView = collectionView
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let searchDateVC = SearchDateViewController()
+        
+        guard let datasource = self.collectionView?.dataSource as? RecommendationDataSource else { return }
+        
+        let place = datasource.recommendationData[indexPath.item]
+        searchDateVC.queryParameter?.place = place
+        self.navigationController?.pushViewController(searchDateVC, animated: true)
+    }
+        
+}
+
+extension RecommandationDelegate: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        guard let collectionView = self.collectionView else { return CGSize()}
+        let size = CGSize(width: collectionView.frame.width, height: 64)
+        return size
+    }
+}

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/RecommendationDataSource.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/RecommendationDataSource.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class RecommendationDataSource: NSObject, UICollectionViewDataSource {
     
-    private var recommendationData = [Place]()
+    private(set) var recommendationData = [Place]()
     
     private var didLoadData: () -> Void
     

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/RecommendationDataSource.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/RecommendationDataSource.swift
@@ -22,7 +22,8 @@ class RecommendationDataSource: NSObject, UICollectionViewDataSource {
         let location = Location.makeRandomInKR()
         let recommendSuccessStubRequest = DefaultRecommendator(httpService: ResponseSuccessStub())
         
-        recommendSuccessStubRequest.recommend(for: location) { place in
+        recommendSuccessStubRequest.recommend(for: location) { [weak self] place in
+            guard let self = self else { return }
             guard let place = place else { return }
             self.recommendationData = place
             didLoadData()

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/SearchLocationViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/SearchLocationViewController.swift
@@ -94,7 +94,6 @@ extension SearchLocationViewController: UICollectionViewDelegate {
         let localSearch = MKLocalSearch(request: request)
         localSearch.start { response, error in
             guard error == nil else { return }
-            // TODO: Search 결과 갯수에 따라, 추가적으로 컬렉션 뷰에 띄우거나 혹은 바로 날짜 선택 화면으로 이동
             guard let response = response else { return }
             
             // 검색 결과가 여러개일때 Datasource, Delegate 변경
@@ -109,6 +108,15 @@ extension SearchLocationViewController: UICollectionViewDelegate {
             }
             
             else {
+                // 검색한 Mapitem 을 nextVC로 넘겨주어야 함
+                guard let mapItem = response.mapItems.first else { return }
+                guard let placeName = mapItem.name else { return }
+                let latitude = response.mapItems[0].placemark.coordinate.latitude as Coordinate.Degree
+                let longitude = response.mapItems[0].placemark.coordinate.longitude as Coordinate.Degree
+                let coordinate = Coordinate(latitude: latitude, longitude: longitude)
+                
+                let place = Place(name: placeName, location: Location(coordinate: coordinate), estimatedTime: 0)
+                searchDateVC.queryParameter?.place = place
                 self.navigationController?.pushViewController(searchDateVC, animated: true)
             }
         }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/SearchLocationViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/SearchLocationViewController.swift
@@ -94,7 +94,8 @@ extension SearchLocationViewController: UICollectionViewDelegate {
         
         let request = MKLocalSearch.Request(completion: searchCompletion)
         let localSearch = MKLocalSearch(request: request)
-        localSearch.start { response, error in
+        localSearch.start { [weak self] response, error in
+            guard let self = self else { return }
             guard error == nil else { return }
             guard let response = response else { return }
             

--- a/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/SearchLocationViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Location/Controller/SearchLocationViewController.swift
@@ -29,6 +29,8 @@ class SearchLocationViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         collectionView.delegate = self
+        collectionView.dataSource = recommendationDataSource
+        self.navigationItem.searchController?.searchBar.text = nil
     }
     
     private func setDataSource() {


### PR DESCRIPTION
## 작업목록 
#38 

- [x] DetailSearchDelegate & DetailSearchDatasource구현 
- [x] 캘린더 화면에서 다시 SearchVC로 돌아왔을 때 초기화 작업 
- [x] 클로저 self를 약한참조로 두어 순환참조 문제 방지 

## 부연설명 
mapitem이 하나일때 셀을 터치했을 때의 로직과 mapItem이 여러개 일때 셀을 터치했을 때 로직이 달라,
DetailSearchDelegate 로 분리해서 처리할 수 있도록  구현. 


https://user-images.githubusercontent.com/59790540/171570073-7e0383b8-8eda-43f5-ae91-ba0b8be67722.mp4

