### PR TITLE
[iOS] 하단 툴바의 '건너뛰기' '지우기' '다음' 버튼을 사용할 수 있음

### DIFF
--- a/iOS/Targets/Cherrybnb/Sources/Common/QueryParameter.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Common/QueryParameter.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct QueryParameter {
-    var dateRange: (Date?, Date?)?
+    var dateRange: (Date?, Date?)
     var place: Place?
     var priceRange: Range<Decimal>?
     var people: HeadCount?

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
@@ -75,7 +75,7 @@ class CalendarPickerViewController: UIViewController {
     func didSelectDate(completion: ((DaySelection) -> Void)?) {
         calendarPicker.didSelectDate = completion
     }
-    
+
     func deselectAll() {
         calendarPicker.deselectAll()
     }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
@@ -37,6 +37,7 @@ class CalendarPickerViewController: UIViewController {
     init(baseDate: Date, numOfMonths: Int) {
         self.calendarPicker = CalendarPicker(baseDate: baseDate, numOfMonths: numOfMonths)
         super.init(nibName: nil, bundle: nil)
+        self.view.translatesAutoresizingMaskIntoConstraints = false
     }
 
     required init?(coder: NSCoder) {
@@ -73,6 +74,11 @@ class CalendarPickerViewController: UIViewController {
 
     func didSelectDate(completion: ((DaySelection) -> Void)?) {
         calendarPicker.didSelectDate = completion
+    }
+    
+    func deselectAll() {
+        calendarPicker.deselectAll()
+        collectionView.reloadData()
     }
 }
 

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/CalendarPickerViewController.swift
@@ -78,7 +78,6 @@ class CalendarPickerViewController: UIViewController {
     
     func deselectAll() {
         calendarPicker.deselectAll()
-        collectionView.reloadData()
     }
 }
 

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/SearchDateViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/SearchDateViewController.swift
@@ -15,48 +15,102 @@ class SearchDateViewController: UIViewController {
             queryParameterStackView.setContent(queryParameter)
         }
     }
+    
+    private lazy var toolbar = SearchNavigationToolbar()
 
-    lazy var queryParameterStackView = QueryParameterStackView(queryParameter: queryParameter)
-
-    lazy var calendarPickerVC = CalendarPickerViewController(baseDate: Date(), numOfMonths: CalendarPickerViewController.defaultNumberOfMonths)
+    private lazy var calendarPickerVC = CalendarPickerViewController(baseDate: Date(), numOfMonths: CalendarPickerViewController.defaultNumberOfMonths)
+    
+    private lazy var queryParameterStackView = QueryParameterStackView(queryParameter: queryParameter)
 
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
         setSubviews()
         setLayout()
-        setHandler()
+        setCalendarPickerHandler()
+        setToolbarHandler()
     }
-
+    
     private func setSubviews() {
         addChild(calendarPickerVC)
         view.addSubview(calendarPickerVC.view)
         calendarPickerVC.didMove(toParent: self)
 
         view.addSubview(queryParameterStackView)
-    }
-
-    private func setHandler() {
-        calendarPickerVC.didSelectDate { [weak self] daySelection in
-            self?.queryParameter.dateRange = (daySelection.checkIn?.date, daySelection.checkOut?.date)
-        }
+        view.addSubview(toolbar)
     }
 
     private func setLayout() {
-        calendarPickerVC.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            calendarPickerVC.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
-            calendarPickerVC.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            calendarPickerVC.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            calendarPickerVC.view.heightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.heightAnchor, multiplier: 0.7)
+            toolbar.bottomAnchor.constraint(equalToSystemSpacingBelow: view.safeAreaLayoutGuide.bottomAnchor, multiplier: 0),
+            toolbar.leadingAnchor.constraint(equalToSystemSpacingAfter: view.safeAreaLayoutGuide.leadingAnchor, multiplier: 0),
+            toolbar.trailingAnchor.constraint(equalToSystemSpacingAfter: view.safeAreaLayoutGuide.trailingAnchor, multiplier: 0),
         ])
-
+        
         NSLayoutConstraint.activate([
-            queryParameterStackView.bottomAnchor.constraint(equalTo: view.readableContentGuide.bottomAnchor),
+            queryParameterStackView.bottomAnchor.constraint(equalTo: toolbar.topAnchor),
             queryParameterStackView.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),
             queryParameterStackView.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
             queryParameterStackView.heightAnchor.constraint(equalToConstant: 44*4)
         ])
+        
+        NSLayoutConstraint.activate([
+            calendarPickerVC.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            calendarPickerVC.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            calendarPickerVC.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            calendarPickerVC.view.bottomAnchor.constraint(equalTo: queryParameterStackView.topAnchor, constant: -16)
+        ])
+    }
+    
+    
+}
 
+
+// MARK: - Handling CalendarPicker
+
+extension SearchDateViewController {
+    private func setCalendarPickerHandler() {
+        calendarPickerVC.didSelectDate { [weak self] daySelection in
+            self?.queryParameter.dateRange = (daySelection.checkIn?.date, daySelection.checkOut?.date)
+            self?.updateToolbarItems(daySelection: daySelection)
+        }
+    }
+}
+
+// MARK: - Handling Navigation Toolbar
+
+extension SearchDateViewController {
+    
+    private func setToolbarHandler() {
+        toolbar.didTouchNext = { [weak self] in
+            let nextVC = UIViewController()
+            // TODO: query 파라미터 주입
+            self?.navigationController?.pushViewController(nextVC, animated: true)
+        }
+        
+        toolbar.didTouchSkip = { [weak self] in
+            let nextVC = UIViewController()
+            // TODO: query 파라미터 초기화 후 주입
+            self?.navigationController?.pushViewController(nextVC, animated: true)
+        }
+        
+        toolbar.didTouchReset = { [weak self] in
+            self?.calendarPickerVC.deselectAll()
+        }
+    }
+    
+    func updateToolbarItems(daySelection: DaySelection) {
+        switch (daySelection.checkIn, daySelection.checkOut) {
+        case (.some(_), .some(_)):
+            toolbar.enableNextButton()
+        case (.some(_), nil):
+            toolbar.showResetButton()
+            toolbar.disableNextButton()
+        case (nil, nil):
+            toolbar.showSkipButton()
+            toolbar.disableNextButton()
+        default:
+            break
+        }
     }
 }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/SearchDateViewController.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Controller/SearchDateViewController.swift
@@ -15,11 +15,11 @@ class SearchDateViewController: UIViewController {
             queryParameterStackView.setContent(queryParameter)
         }
     }
-    
+
     private lazy var toolbar = SearchNavigationToolbar()
 
     private lazy var calendarPickerVC = CalendarPickerViewController(baseDate: Date(), numOfMonths: CalendarPickerViewController.defaultNumberOfMonths)
-    
+
     private lazy var queryParameterStackView = QueryParameterStackView(queryParameter: queryParameter)
 
     override func viewDidLoad() {
@@ -30,7 +30,7 @@ class SearchDateViewController: UIViewController {
         setCalendarPickerHandler()
         setToolbarHandler()
     }
-    
+
     private func setSubviews() {
         addChild(calendarPickerVC)
         view.addSubview(calendarPickerVC.view)
@@ -44,16 +44,16 @@ class SearchDateViewController: UIViewController {
         NSLayoutConstraint.activate([
             toolbar.bottomAnchor.constraint(equalToSystemSpacingBelow: view.safeAreaLayoutGuide.bottomAnchor, multiplier: 0),
             toolbar.leadingAnchor.constraint(equalToSystemSpacingAfter: view.safeAreaLayoutGuide.leadingAnchor, multiplier: 0),
-            toolbar.trailingAnchor.constraint(equalToSystemSpacingAfter: view.safeAreaLayoutGuide.trailingAnchor, multiplier: 0),
+            toolbar.trailingAnchor.constraint(equalToSystemSpacingAfter: view.safeAreaLayoutGuide.trailingAnchor, multiplier: 0)
         ])
-        
+
         NSLayoutConstraint.activate([
             queryParameterStackView.bottomAnchor.constraint(equalTo: toolbar.topAnchor),
             queryParameterStackView.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),
             queryParameterStackView.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
             queryParameterStackView.heightAnchor.constraint(equalToConstant: 44*4)
         ])
-        
+
         NSLayoutConstraint.activate([
             calendarPickerVC.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
             calendarPickerVC.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
@@ -61,10 +61,8 @@ class SearchDateViewController: UIViewController {
             calendarPickerVC.view.bottomAnchor.constraint(equalTo: queryParameterStackView.topAnchor, constant: -16)
         ])
     }
-    
-    
-}
 
+}
 
 // MARK: - Handling CalendarPicker
 
@@ -80,30 +78,30 @@ extension SearchDateViewController {
 // MARK: - Handling Navigation Toolbar
 
 extension SearchDateViewController {
-    
+
     private func setToolbarHandler() {
         toolbar.didTouchNext = { [weak self] in
             let nextVC = UIViewController()
             // TODO: query 파라미터 주입
             self?.navigationController?.pushViewController(nextVC, animated: true)
         }
-        
+
         toolbar.didTouchSkip = { [weak self] in
             let nextVC = UIViewController()
             // TODO: query 파라미터 초기화 후 주입
             self?.navigationController?.pushViewController(nextVC, animated: true)
         }
-        
+
         toolbar.didTouchReset = { [weak self] in
             self?.calendarPickerVC.deselectAll()
         }
     }
-    
+
     func updateToolbarItems(daySelection: DaySelection) {
         switch (daySelection.checkIn, daySelection.checkOut) {
-        case (.some(_), .some(_)):
+        case (.some, .some):
             toolbar.enableNextButton()
-        case (.some(_), nil):
+        case (.some, nil):
             toolbar.showResetButton()
             toolbar.disableNextButton()
         case (nil, nil):

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/CalendarPicker.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/CalendarPicker.swift
@@ -58,7 +58,7 @@ struct CalendarPicker {
     func getDay(monthSection: Int, dayItem: Int) -> Day {
         return months[monthSection].days[dayItem]
     }
-    
+
     mutating func deselectAll() {
         switch (daySelection.checkIn, daySelection.checkOut) {
         case (.some(let checkIn), .some(let checkOut)):
@@ -66,15 +66,15 @@ struct CalendarPicker {
             toggleSelection(of: checkOut)
             toggleBetweenSelection(from: checkIn, to: checkOut)
             updateSections(including: [checkIn, checkOut])
-            
+
         case (.some(let checkIn), nil):
             toggleSelection(of: checkIn)
             updateSections(including: [checkIn])
-            
+
         default:
             break
         }
-        
+
         daySelection = (nil, nil)
     }
 
@@ -208,9 +208,4 @@ struct CalendarPicker {
     private mutating func toggleSelection(monthSection: Int, dayItem: Int) {
         months[monthSection].days[dayItem].isSelected.toggle()
     }
-}
-
-enum CalendarPickerError: Error {
-    case metadataGeneration
-    case offsetMonthGeneration
 }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/CalendarPicker.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/Model/CalendarPicker.swift
@@ -58,6 +58,24 @@ struct CalendarPicker {
     func getDay(monthSection: Int, dayItem: Int) -> Day {
         return months[monthSection].days[dayItem]
     }
+    
+    mutating func deselectAll() {
+        if let checkIn = daySelection.checkIn , let checkOut = daySelection.checkOut {
+            toggleSelection(of: checkIn)
+            toggleSelection(of: checkOut)
+            toggleBetweenSelection(from: checkIn, to: checkOut)
+            if let updatedRange = getUpdatedSectionRange(days: [checkIn, checkOut]) {
+                didUpdateMonth?(updatedRange)
+            }
+        } else if let checkIn = daySelection.checkIn {
+            toggleSelection(of: checkIn)
+            if let updatedRange = getUpdatedSectionRange(days: [checkIn]) {
+                didUpdateMonth?(updatedRange)
+            }
+        }
+        
+        daySelection = (nil, nil)
+    }
 
     mutating func select(newMonthSection: Int, newDayItem: Int) {
         let selectedDay = getDay(monthSection: newMonthSection, dayItem: newDayItem)

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/View/CalendarPickerViewCell.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/View/CalendarPickerViewCell.swift
@@ -12,7 +12,7 @@ class CalendarPickerViewCell: UICollectionViewCell {
     static let reuseIdentifier = String(describing: CalendarPickerViewCell.self)
 
     // MARK: - Subviews
-    
+
     private let dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "d"
@@ -47,17 +47,17 @@ class CalendarPickerViewCell: UICollectionViewCell {
     }()
 
     // MARK: - Initializers
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setSubviews()
         setLayout()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Public Method
 
     func setContent(_ day: Day) {
@@ -77,14 +77,14 @@ class CalendarPickerViewCell: UICollectionViewCell {
             numberLabel.attributedText = normal(dateString)
         }
     }
-    
+
     override func prepareForReuse() {
         numberLabel.text = nil
         numberLabel.attributedText = nil
         selectionBackgroundView.isHidden = true
         inBetweenSelectionBackgroundView.isHidden = true
     }
-    
+
     // MARK: - Private (helper) methods
 
     private func setSubviews() {
@@ -113,7 +113,7 @@ class CalendarPickerViewCell: UICollectionViewCell {
             inBetweenSelectionBackgroundView.topAnchor.constraint(equalTo: contentView.topAnchor)
         ])
     }
-    
+
     private func selected(_ string: String) -> NSAttributedString {
         let attributes: [NSAttributedString.Key: Any] = [
             .font: UIFont.systemFont(ofSize: 18, weight: .medium),

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/View/CalendarPickerViewSectionHeader.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/View/CalendarPickerViewSectionHeader.swift
@@ -28,7 +28,7 @@ class CalendarPickerViewSectionHeader: UICollectionReusableView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = .systemYellow
+        backgroundColor = .white
         setSubviews()
         setLayout()
     }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/View/QueryParameterStackView.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/View/QueryParameterStackView.swift
@@ -15,6 +15,7 @@ class QueryParameterStackView: UIStackView {
     lazy var parameterRow: (String, String) -> UIStackView = { keyText, valueText in
         let stackView = UIStackView()
         stackView.axis = .horizontal
+        stackView.spacing = 8
         let keyLabel = self.parameterKeyLabel(keyText)
         let valueLabel = self.parameterValueLabel(valueText)
         stackView.addArrangedSubview(keyLabel)
@@ -26,6 +27,7 @@ class QueryParameterStackView: UIStackView {
         let label = UILabel()
         label.text = text
         label.textAlignment = .left
+        label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         return label
     }
     
@@ -34,6 +36,7 @@ class QueryParameterStackView: UIStackView {
         label.text = text
         label.textAlignment = .right
         label.textColor = .gray
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return label
     }
     
@@ -106,6 +109,7 @@ class QueryParameterStackView: UIStackView {
     
     private func toString(_ range: (Date?, Date?)?) -> String {
         guard let range = range else { return "" }
+
         
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MMM d일"

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/View/QueryParameterStackView.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/View/QueryParameterStackView.swift
@@ -9,9 +9,9 @@
 import UIKit
 
 class QueryParameterStackView: UIStackView {
-    
+
     // MARK: - Subviews
-    
+
     lazy var parameterRow: (String, String) -> UIStackView = { keyText, valueText in
         let stackView = UIStackView()
         stackView.axis = .horizontal
@@ -22,7 +22,7 @@ class QueryParameterStackView: UIStackView {
         stackView.addArrangedSubview(valueLabel)
         return stackView
     }
-    
+
     lazy var parameterKeyLabel: (String) -> UILabel = { text in
         let label = UILabel()
         label.text = text
@@ -30,7 +30,7 @@ class QueryParameterStackView: UIStackView {
         label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         return label
     }
-    
+
     lazy var parameterValueLabel: (String) -> UILabel = { text in
         let label = UILabel()
         label.text = text
@@ -39,62 +39,62 @@ class QueryParameterStackView: UIStackView {
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return label
     }
-    
+
     // MARK: - Properties
-    
+
     var queryParameter: QueryParameter?
-    
+
     // MARK: - Initializers
-    
+
     init(queryParameter: QueryParameter?) {
         self.queryParameter = queryParameter
         super.init(frame: .zero)
         setDisplay()
         setSubviews()
     }
-    
+
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Public Method
-    
+
     func setContent(_ queryParameter: QueryParameter) {
         self.queryParameter = queryParameter
         removeSubviews()
         setSubviews()
     }
-    
+
     // MARK: - Private (helper) Method
-    
+
     private func removeSubviews() {
         self.subviews.forEach { subview in
             subview.removeFromSuperview()
         }
     }
-    
+
     private func setDisplay() {
         self.translatesAutoresizingMaskIntoConstraints = false
         self.axis = .vertical
         self.spacing = 2
         self.distribution = .fillEqually
     }
-    
+
     private func setSubviews() {
         for (keyText, valueText) in toString(queryParameter) {
             let parameterRow = parameterRow(keyText, valueText)
             addArrangedSubview(parameterRow)
         }
     }
-    
+
     private func toString(_ queryParameter: QueryParameter?) -> [(String, String)] {
         let locationString = toString(queryParameter?.place)
         let dateString = toString(queryParameter?.dateRange)
-        
+
         // TODO: Formatting Logic for price & headCount
         let priceString = ""
         let headCountString = ""
-        
+
         return [
             ("위치", locationString),
             ("체크인/체크아웃", dateString),
@@ -102,19 +102,18 @@ class QueryParameterStackView: UIStackView {
             ("인원", headCountString)
         ]
     }
-    
+
     private func toString(_ place: Place?) -> String {
         return place?.name ?? ""
     }
-    
+
     private func toString(_ range: (Date?, Date?)?) -> String {
         guard let range = range else { return "" }
 
-        
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MMM d일"
         dateFormatter.locale = Locale(identifier: "ko")
-        
+
         switch range {
         case (.some(let checkIn), .some(let checkOut)):
             return dateFormatter.string(from: checkIn) + " - " + dateFormatter.string(from: checkOut)

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/View/SearchNavigationToolbar.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/View/SearchNavigationToolbar.swift
@@ -9,58 +9,58 @@
 import UIKit
 
 class SearchNavigationToolbar: UIToolbar {
-    
+
     private var skipButton = UIBarButtonItem(title: "건너뛰기", style: .plain, target: nil, action: #selector(skipButtonTouched))
     private var emptySpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
     private var resetButton = UIBarButtonItem(title: "지우기", style: .plain, target: nil, action: #selector(resetButtonTouched))
     private var nextButton = UIBarButtonItem(title: "다음", style: .plain, target: nil, action: #selector(nextButtonTouched))
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.translatesAutoresizingMaskIntoConstraints = false
         setSubviews()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     private func setSubviews() {
         nextButton.isEnabled = false
         setItems([skipButton, emptySpace, nextButton], animated: false)
     }
-    
+
     var didTouchReset: (() -> Void)?
     var didTouchSkip: (() -> Void)?
     var didTouchNext: (() -> Void)?
-    
+
     @objc private func nextButtonTouched(_ sender: UIButton) {
         didTouchNext?()
     }
-    
+
     @objc private func skipButtonTouched(_ sender: UIButton) {
         didTouchSkip?()
     }
-    
+
     @objc private func resetButtonTouched(_ sender: UIButton) {
         showSkipButton()
         didTouchReset?()
     }
-    
+
     func enableNextButton() {
         items?[2].isEnabled = true
     }
-    
+
     func disableNextButton() {
         items?[2].isEnabled = false
     }
-    
+
     func showResetButton() {
         items?[0] = resetButton
     }
-    
+
     func showSkipButton() {
         items?[0] = skipButton
     }
-    
+
 }

--- a/iOS/Targets/Cherrybnb/Sources/Search_Date/View/SearchNavigationToolbar.swift
+++ b/iOS/Targets/Cherrybnb/Sources/Search_Date/View/SearchNavigationToolbar.swift
@@ -1,0 +1,66 @@
+//
+//  SearchNavigationToolBar.swift
+//  Cherrybnb
+//
+//  Created by Bumgeun Song on 2022/06/07.
+//  Copyright © 2022 Codesquad. All rights reserved.
+//
+
+import UIKit
+
+class SearchNavigationToolbar: UIToolbar {
+    
+    private var skipButton = UIBarButtonItem(title: "건너뛰기", style: .plain, target: nil, action: #selector(skipButtonTouched))
+    private var emptySpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+    private var resetButton = UIBarButtonItem(title: "지우기", style: .plain, target: nil, action: #selector(resetButtonTouched))
+    private var nextButton = UIBarButtonItem(title: "다음", style: .plain, target: nil, action: #selector(nextButtonTouched))
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.translatesAutoresizingMaskIntoConstraints = false
+        setSubviews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setSubviews() {
+        nextButton.isEnabled = false
+        setItems([skipButton, emptySpace, nextButton], animated: false)
+    }
+    
+    var didTouchReset: (() -> Void)?
+    var didTouchSkip: (() -> Void)?
+    var didTouchNext: (() -> Void)?
+    
+    @objc private func nextButtonTouched(_ sender: UIButton) {
+        didTouchNext?()
+    }
+    
+    @objc private func skipButtonTouched(_ sender: UIButton) {
+        didTouchSkip?()
+    }
+    
+    @objc private func resetButtonTouched(_ sender: UIButton) {
+        showSkipButton()
+        didTouchReset?()
+    }
+    
+    func enableNextButton() {
+        items?[2].isEnabled = true
+    }
+    
+    func disableNextButton() {
+        items?[2].isEnabled = false
+    }
+    
+    func showResetButton() {
+        items?[0] = resetButton
+    }
+    
+    func showSkipButton() {
+        items?[0] = skipButton
+    }
+    
+}


### PR DESCRIPTION
## 작업 목록
#48 

## Screenshot

![navigation_toolbar_demo](https://user-images.githubusercontent.com/17468015/172307398-f6bc2d7f-46fa-44ee-aaa0-568853e970c7.gif)


## 고민과 해결

- 네비게이션 툴바는 이후의 뷰에서도 사용되므로 재사용가능하도록 설계했음.
- 상위 뷰에서 **다음과 같이 툴바에서 발생한 이벤트에 대한 핸들링**이 가능함

```swift
private func setToolbarHandler() {
  toolbar.didTouchNext = { [weak self] in
      let nextVC = UIViewController()
      // TODO: query 파라미터 주입
      self?.navigationController?.pushViewController(nextVC, animated: true)
  }
  
  toolbar.didTouchSkip = { [weak self] in
      let nextVC = UIViewController()
      // TODO: query 파라미터 초기화 후 주입
      self?.navigationController?.pushViewController(nextVC, animated: true)
  }
  
  toolbar.didTouchReset = { [weak self] in
      self?.calendarPickerVC.deselectAll()
  }
}
```